### PR TITLE
fix G0 parsing so it works w/ Cura reprap gcode files...

### DIFF
--- a/gcodeParser.py
+++ b/gcodeParser.py
@@ -59,7 +59,7 @@ class GcodeParser:
 	def parse_G0(self, args):
 		# G0: Rapid move
 		# same as a controlled move for us (& reprap FW)
-		self.G1(args, "G0")
+		self.parse_G1(args, "G0")
 		
 	def parse_G1(self, args, type="G1"):
 		# G1: Controlled move


### PR DESCRIPTION
looks like G0 parsing code was broken during a reorg.  Call the correct function, and this fixes it w/ my gcode files.