### PR TITLE
Fix implicit integer division

### DIFF
--- a/yagv
+++ b/yagv
@@ -42,7 +42,7 @@ class App:
 		self.load(path)
 		
 		# default to the middle layer
-		self.layerIdx = len(self.model.layers)/2
+		self.layerIdx = int(len(self.model.layers)/2)
 
 		self.window = MyWindow(self, caption="Yet Another GCode Viewer v%s"%YAGV_VERSION, resizable=True)
 
@@ -187,7 +187,7 @@ class App:
 		self.graphics_limbo = []
 		
 		for layer_idx in xrange(len(self.vertices)):
-			nb_layer_vertices = len(self.vertices[layer_idx])/3
+			nb_layer_vertices = int(len(self.vertices[layer_idx])/3)
 			vertex_list = pyglet.graphics.vertex_list(nb_layer_vertices,
 				('v3f/static', self.vertices[layer_idx]),
 				('c4B/static', self.vertex_colors[0][layer_idx])


### PR DESCRIPTION
This patch corrects the only major issue with python3 compatibility.  Everything else can be handled automatically by the "2to3" tool.