### PR TITLE
Allow leading zero in G0 and G1

### DIFF
--- a/gcodeParser.py
+++ b/gcodeParser.py
@@ -65,6 +65,15 @@ class GcodeParser:
 				dic[letter] = coord
 		return dic
 
+	def parse_G00(self, args):
+		# G00: Rapid move
+		# same as a controlled move for us (& reprap FW)
+		self.parse_G1(args, "G0")
+
+	def parse_G01(self, args, type="G1"):
+		# G01: Controlled move
+		self.model.do_G1(self.parseArgs(args), type)
+
 	def parse_G0(self, args):
 		# G0: Rapid move
 		# same as a controlled move for us (& reprap FW)


### PR DESCRIPTION
The program i'm using to generate gcode (pcb2gcode) sometimes thinks it's cooler to write G00 and G01 than G0 and G1. This patch makes yagv not care.