### PR TITLE
Make it run with pyglet2

### DIFF
--- a/gcodeParser.py
+++ b/gcodeParser.py
@@ -3,7 +3,7 @@
 import math
 import re
 
-class GcodeParser:
+class GcodeParser(object):
 	
 	def __init__(self):
 		self.model = GcodeModel(self)
@@ -100,10 +100,10 @@ class GcodeParser:
 		self.model.do_G92(self.parseArgs(args))
 		
 	def warn(self, msg):
-		print "[WARN] Line %d: %s (Text:'%s')" % (self.lineNb, msg, self.line)
+		print("[WARN] Line %d: %s (Text:'%s')" % (self.lineNb, msg, self.line))
 		
 	def error(self, msg):
-		print "[ERROR] Line %d: %s (Text:'%s')" % (self.lineNb, msg, self.line)
+		print("[ERROR] Line %d: %s (Text:'%s')" % (self.lineNb, msg, self.line))
 		raise Exception("[ERROR] Line %d: %s (Text:'%s')" % (self.lineNb, msg, self.line))
 
 class BBox(object):
@@ -139,7 +139,7 @@ class BBox(object):
 		self.zmin = min(self.zmin, coords["Z"])
 		self.zmax = max(self.zmax, coords["Z"])
 		
-class GcodeModel:
+class GcodeModel(object):
 	
 	def __init__(self, parser):
 		# save parser for messages
@@ -172,7 +172,7 @@ class GcodeModel:
 		coords = dict(self.relative)
 		# update changed coords
 		for axis in args.keys():
-			if coords.has_key(axis):
+			if axis in coords:
 				if self.isRelative:
 					coords[axis] += args[axis]
 				else:
@@ -205,11 +205,11 @@ class GcodeModel:
 		# this changes the current coords, without moving, so do not generate a segment
 		
 		# no axes mentioned == all axes to 0
-		if not len(args.keys()):
+		if not args:
 			args = {"X":0.0, "Y":0.0, "Z":0.0, "E":0.0}
 		# update specified axes
 		for axis in args.keys():
-			if self.offset.has_key(axis):
+			if axis in self.offset:
 				# transfer value from relative to offset
 				self.offset[axis] += self.relative[axis] - args[axis]
 				self.relative[axis] = args[axis]
@@ -376,7 +376,7 @@ class GcodeModel:
 	def __str__(self):
 		return "<GcodeModel: len(segments)=%d, len(layers)=%d, distance=%f, extrudate=%f, bbox=%s>"%(len(self.segments), len(self.layers), self.distance, self.extrudate, self.bbox)
 	
-class Segment:
+class Segment(object):
 	def __init__(self, type, coords, lineNb, line):
 		self.type = type
 		self.coords = coords
@@ -389,7 +389,7 @@ class Segment:
 	def __str__(self):
 		return "<Segment: type=%s, lineNb=%d, style=%s, layerIdx=%d, distance=%f, extrudate=%f>"%(self.type, self.lineNb, self.style, self.layerIdx, self.distance, self.extrudate)
 		
-class Layer:
+class Layer(object):
 	def __init__(self, Z):
 		self.Z = Z
 		self.segments = []
@@ -406,4 +406,4 @@ if __name__ == '__main__':
 	parser = GcodeParser()
 	model = parser.parseFile(path)
 
-	print model
+	print(model)

--- a/yagv
+++ b/yagv
@@ -10,6 +10,8 @@ pyglet.options['debug_gl'] = False
 
 from pyglet import clock
 from pyglet.gl import *
+from pyglet.graphics.shader import Shader, ShaderProgram
+from pyglet.math import Vec3,Mat4
 from pyglet.window import key
 from pyglet.window import mouse
 
@@ -22,6 +24,43 @@ class App(object):
 		self.RX = 0.0
 		self.RZ = 0.0
 		self.zoom = 1.0
+		
+		# =========================
+		# Shader
+		# =========================
+
+		vertex_source = """
+		#version 330 core
+		in vec3 position;
+		in vec4 color;
+
+		out vec4 v_color;
+
+		uniform mat4 mvp;
+
+		void main()
+		{
+			v_color = color;
+			gl_Position = mvp * vec4(position, 1.0);
+		}
+		"""
+
+		fragment_source = """
+		#version 330 core
+		in vec4 v_color;
+		out vec4 fragColor;
+
+		void main()
+		{
+			fragColor = vec4(v_color);
+		}
+		"""
+
+		self.program = ShaderProgram(
+			Shader(vertex_source, "vertex"),
+			Shader(fragment_source, "fragment")
+		)	
+		
 	
 	def main(self):
 		
@@ -49,6 +88,8 @@ class App(object):
 		# debug: log all events
 		# self.window.push_handlers(pyglet.window.event.WindowEventLogger())
 		
+		# generate graphics AFTER window generation
+		self.generateGraphics()
 
 		pyglet.app.run()
 
@@ -188,24 +229,29 @@ class App(object):
 		
 		for layer_idx in range(len(self.vertices)):
 			nb_layer_vertices = int(len(self.vertices[layer_idx])/3)
-			vertex_list = pyglet.graphics.vertex_list(nb_layer_vertices,
-				('v3f/static', self.vertices[layer_idx]),
-				('c4B/static', self.vertex_colors[0][layer_idx])
+			vertex_list = self.program.vertex_list(nb_layer_vertices,
+				GL_LINES,
+				position = ('f', self.vertices[layer_idx]),
+				color = ('Bn', self.vertex_colors[0][layer_idx])
 			)
 			self.graphics_old.append(vertex_list)
 			
-			vertex_list = pyglet.graphics.vertex_list(nb_layer_vertices,
-				('v3f/static', self.vertices[layer_idx]),
-				('c4B/static', self.vertex_colors[1][layer_idx])
+			vertex_list = self.program.vertex_list(nb_layer_vertices,
+				GL_LINES,
+				position = ('f', self.vertices[layer_idx]),
+				color = ('Bn', self.vertex_colors[1][layer_idx])
 			)
 			self.graphics_current.append(vertex_list)
 			
-			vertex_list = pyglet.graphics.vertex_list(nb_layer_vertices,
-				('v3f/static', self.vertices[layer_idx]),
-				('c4B/static', self.vertex_colors[2][layer_idx])
+			vertex_list = self.program.vertex_list(nb_layer_vertices,
+				GL_LINES,
+				position = ('f', self.vertices[layer_idx]),
+				color = ('Bn', self.vertex_colors[2][layer_idx])
 			)
 			self.graphics_limbo.append(vertex_list)
-		#	print nb_layer_vertices, len(self.vertices[layer_idx]), len(self.colors[0][layer_idx])
+			#print(layer_idx, nb_layer_vertices, len(self.vertices[layer_idx]), len(self.vertex_colors[0][layer_idx]))
+
+
 		
 		t2 = time.time()
 		print("end generateGraphics in %0.3f ms" % ((t2-t1)*1000.0, ))
@@ -276,6 +322,30 @@ class MyWindow(pyglet.window.Window):
 		pyglet.window.Window.__init__(self, **kwargs)
 		self.app = app
 		self.hud()
+
+		# Axes
+		axes_pos = [
+			0,0,0, self.app.model.bbox.xmax,0,0,
+			0,0,0, 0,self.app.model.bbox.ymax,0,
+			0,0,0, 0,0,self.app.model.bbox.zmax
+		]
+
+		axes_col = [
+			1,0,0,1, 1,0,0,1,
+			0,1,0,1, 0,1,0,1,
+			0,0,1,1, 0,0,1,1
+		]
+
+		self.axes = self.app.program.vertex_list(
+			6,
+			GL_LINES,
+			position=('f', axes_pos),
+			color=('f', axes_col)
+		)
+		
+		
+		
+		self.rotation_matrix = Mat4()  # Start als Identität
 	
 	# hud info
 	def hud(self):
@@ -403,34 +473,30 @@ class MyWindow(pyglet.window.Window):
 		#print 'mouse scroll:', `x, y, dx, dy`, `z, self.app.zoom`
 
 	def on_draw(self):
-		#print "draw"
+		#print("draw")
 		
 		# Clear buffers
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 		
-		# setup projection
-		glMatrixMode(GL_PROJECTION)
-		glLoadIdentity()
-		gluPerspective(65, self.width / float(self.height), 0.1, 1000)
-		
+		projection = Mat4.perspective_projection(
+			self.width / self.height, 
+			fov = 65,
+			z_near = 0.1, 
+			z_far = 10000.0
+		)
+
 		# setup camera
-		glMatrixMode(GL_MODELVIEW)
-		glLoadIdentity()
-		gluLookAt(0,1.5,2,0,0,0,0,1,0)
+		view = Mat4.look_at(Vec3(0,1.5,2),Vec3(0,0,0),Vec3(0,1,0))
 		
 		# enable alpha blending
 		glEnable(GL_BLEND)
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 		
 		# rotate axes to match reprap style
-		glRotated(-90, 1,0,0)
+		reprap = Mat4.from_rotation(math.radians(-90), (1,0,0))
 		# user rotate model
-		glRotated(-self.app.RX, 1,0,0)
-		glRotated(self.app.RZ, 0,0,1)
-		
-		# Todo check this
-		glTranslated(0,0,-0.5)
-		
+		rot_x = Mat4.from_rotation(math.radians(-self.app.RX), (1, 0, 0))  
+		rot_z = Mat4.from_rotation(math.radians(self.app.RZ), (0,0,1))
 		# fit & user zoom model
 		max_width = max(
 			self.app.model.bbox.dx(),
@@ -438,42 +504,34 @@ class MyWindow(pyglet.window.Window):
 			self.app.model.bbox.dz()
 		)
 		scale = self.app.zoom / max_width
-		glScaled(scale, scale, scale)
+		scale = Mat4.from_scale((scale, scale, scale))
+		trans = Mat4.from_translation((-self.app.model.bbox.cx(), -self.app.model.bbox.cy(), -self.app.model.bbox.cz()))
+		model = reprap @ rot_x @ rot_z @ scale @ trans
 		
-		glTranslated(-self.app.model.bbox.cx(), -self.app.model.bbox.cy(), -self.app.model.bbox.cz())
+		mvp = projection @ view @ model
+
+		with self.app.program:
+			self.app.program['mvp'] = mvp
+			
+			#draw axes
+			glLineWidth(3)
+			self.axes.draw(GL_LINES)
+
+			glLineWidth(1)
+			# Draw the model layers
+			# lower layers
+			for graphic in self.app.graphics_old[0:self.app.layerIdx]:
+				graphic.draw(GL_LINES)
 		
-		
-		
-		# draw axes
-		glBegin(GL_LINES)
-		glColor3f(1,0,0)
-		glVertex3f(0,0,0); glVertex3f(1,0,0); glVertex3f(1,0,0); glVertex3f(1,0.1,0)
-		glVertex3f(1,0,0); glVertex3f(self.app.model.bbox.xmax,0,0)
-		glColor3f(0,1,0)
-		glVertex3f(0,0,0); glVertex3f(0,1,0); glVertex3f(0,1,0); glVertex3f(0,1,0.1)
-		glVertex3f(0,1,0); glVertex3f(0,self.app.model.bbox.ymax,0)
-		glColor3f(0,0,1)
-		glVertex3f(0,0,0); glVertex3f(0,0,1); glVertex3f(0,0,1); glVertex3f(0.1,0,1)
-		glVertex3f(0,0,1); glVertex3f(0,0,self.app.model.bbox.zmax)
-		glEnd()
-		
-		
-		glLineWidth(1)
-		# Draw the model layers
-		# lower layers
-		for graphic in self.app.graphics_old[0:self.app.layerIdx]:
+			glLineWidth(2)
+			# highlighted layer
+			graphic = self.app.graphics_current[self.app.layerIdx]
 			graphic.draw(GL_LINES)
-		
-		glLineWidth(2)
-		
-		# highlighted layer
-		graphic = self.app.graphics_current[self.app.layerIdx]
-		graphic.draw(GL_LINES)
-		
-		glLineWidth(1)
-		# limbo layers
-		for graphic in self.app.graphics_limbo[self.app.layerIdx+1:]:
-			graphic.draw(GL_LINES)
+			
+			glLineWidth(1)
+			# limbo layers
+			for graphic in self.app.graphics_limbo[self.app.layerIdx+1:]:
+				graphic.draw(GL_LINES)
 		
 		
 		# disable depth for HUD
@@ -482,13 +540,10 @@ class MyWindow(pyglet.window.Window):
 		
 		#Set your camera up for 2d, draw 2d scene
 		
-		glMatrixMode(GL_PROJECTION)
-		glLoadIdentity();
-		glOrtho(0, self.width, 0, self.height, -1, 1)
-		glMatrixMode(GL_MODELVIEW)
-		glLoadIdentity()
+		self.projection = Mat4.orthogonal_projection(0, self.width, 0, self.height, -1, 1)
+		self.view = Mat4()
 		
-		self.fpsLabel.text = "%d fps"%int(round(pyglet.clock.get_fps()))
+		self.fpsLabel.text = "%d fps"%int(round(pyglet.clock.get_frequency()))
 		
 		for label in self.blLabels:
 			label.draw()

--- a/yagv
+++ b/yagv
@@ -17,7 +17,7 @@ from gcodeParser import *
 import os.path
 import time
 
-class App:
+class App(object):
 	def __init__(self):
 		self.RX = 0.0
 		self.RZ = 0.0
@@ -26,7 +26,7 @@ class App:
 	def main(self):
 		
 		#### MAIN CODE ####
-		print "Yet Another GCode Viewer v%s"%YAGV_VERSION
+		print("Yet Another GCode Viewer v%s"%YAGV_VERSION)
 
 		import sys
 		if len(sys.argv) > 1:
@@ -42,7 +42,7 @@ class App:
 		self.load(path)
 		
 		# default to the middle layer
-		self.layerIdx = len(self.model.layers)/2
+		self.layerIdx = int(len(self.model.layers) / 2)
 
 		self.window = MyWindow(self, caption="Yet Another GCode Viewer v%s"%YAGV_VERSION, resizable=True)
 
@@ -57,35 +57,35 @@ class App:
 			
 	def load(self, path):
 		
-		print "loading file %s ..."%repr(path)
+		print("loading file %s ..."%repr(path))
 		t1 = time.time()
 		
-		print
-		print "Parsing '%s'..."%path
-		print
+		print()
+		print("Parsing '%s'..."%path)
+		print()
 		
 		self.path = path
 
 		parser = GcodeParser()
 		self.model = parser.parseFile(path)
 
-		print
-		print "Done! %s"%self.model
-		print
+		print()
+		print("Done! %s"%self.model)
+		print()
 		
 		# render the model
-		print "rendering vertices..."
+		print("rendering vertices...")
 		self.renderVertices()
-		print "rendering indexed colors..."
+		print("rendering indexed colors...")
 		self.renderIndexedColors()
-		print "rendering true colors..."
+		print("rendering true colors...")
 		self.renderColors()
-		print "generating graphics..."
+		print("generating graphics...")
 		self.generateGraphics()
-		print "Done"
+		print("Done")
 		
 		t2 = time.time()
-		print "loaded file in %0.3f ms" % ((t2-t1)*1000.0, )
+		print("loaded file in %0.3f ms" % ((t2-t1)*1000.0, ))
 	
 	def renderVertices(self):
 		t1 = time.time()
@@ -113,7 +113,7 @@ class App:
 			self.vertices.append(layer_vertices)
 			
 		t2 = time.time()
-		print "end renderColors in %0.3f ms" % ((t2-t1)*1000.0, )
+		print("end renderColors in %0.3f ms" % ((t2-t1)*1000.0, ))
 	
 	def renderIndexedColors(self):
 		t1 = time.time()
@@ -142,7 +142,7 @@ class App:
 			# append layer to all layers
 			self.vertex_indexed_colors.append(layer_vertex_indexed_colors)
 		t2 = time.time()
-		print "end renderIndexedColors in %0.3f ms" % ((t2-t1)*1000.0, )
+		print("end renderIndexedColors in %0.3f ms" % ((t2-t1)*1000.0, ))
 	
 	def renderColors(self):
 		t1 = time.time()
@@ -160,7 +160,7 @@ class App:
 				]
 		
 		# for all 3 types
-		for display_type in xrange(3):
+		for display_type in range(3):
 			
 			type_color_map = colorMap[display_type]
 			
@@ -168,16 +168,16 @@ class App:
 			for indexes in self.vertex_indexed_colors:
 				
 				# render color indexes to colors
-				colors = map(lambda e: type_color_map[e], indexes)
+				colors = [type_color_map[e] for e in indexes]
 				# flatten color values
 				fcolors = []
-				map(fcolors.extend, colors)
+				list(map(fcolors.extend, colors))
 				
 				# push colors to vertex list
 				self.vertex_colors[display_type].append(fcolors)
 				
 		t2 = time.time()
-		print "end renderColors in %0.3f ms" % ((t2-t1)*1000.0, )
+		print("end renderColors in %0.3f ms" % ((t2-t1)*1000.0, ))
 	
 	def generateGraphics(self):
 		t1 = time.time()
@@ -186,8 +186,8 @@ class App:
 		self.graphics_current = []
 		self.graphics_limbo = []
 		
-		for layer_idx in xrange(len(self.vertices)):
-			nb_layer_vertices = len(self.vertices[layer_idx])/3
+		for layer_idx in range(len(self.vertices)):
+			nb_layer_vertices = int(len(self.vertices[layer_idx])/3)
 			vertex_list = pyglet.graphics.vertex_list(nb_layer_vertices,
 				('v3f/static', self.vertices[layer_idx]),
 				('c4B/static', self.vertex_colors[0][layer_idx])
@@ -208,7 +208,7 @@ class App:
 		#	print nb_layer_vertices, len(self.vertices[layer_idx]), len(self.colors[0][layer_idx])
 		
 		t2 = time.time()
-		print "end generateGraphics in %0.3f ms" % ((t2-t1)*1000.0, )
+		print("end generateGraphics in %0.3f ms" % ((t2-t1)*1000.0, ))
 		
 		
 	def rotate_drag_start(self, x, y, button, modifiers):
@@ -358,7 +358,7 @@ class MyWindow(pyglet.window.Window):
 			self.app.layer_drag_end(x, y, button, modifiers)
 
 	def on_key_release(self, symbol, modifiers):
-		print "pressed key: %s, mod: %s"%(symbol, modifiers)
+		print("pressed key: %s, mod: %s"%(symbol, modifiers))
 		#print "pressed key: %s, mod: %s"%(pyglet.window.key.R, pyglet.window.key.MOD_CTRL)
 		if symbol==pyglet.window.key.R and modifiers & pyglet.window.key.MOD_CTRL:
 			self.app.reload()


### PR DESCRIPTION
Starting with debian trixie (debian 13) yagv did not work anymore
Cause is the update of the packaged pyglet from 1.5 to pyglet 2.0

See also issue #25 

This patch is based on the python3 port of hyperair.

It runs on debian 13 with the packaged version of pyglet and should show no change to the user.
Internally it has some quirks for a fast solution with a small changeset. 
A really clean solution would need a rewrite of a greater portion of the code.
(Default frame rate, graphics generated twice for now) 

I do not expect to get this pull request merged, but it may be a starting point for whoever does need this possibility.

